### PR TITLE
fix: pass the actual value, not the function

### DIFF
--- a/src/action-types/frontend/cssRule.js
+++ b/src/action-types/frontend/cssRule.js
@@ -5,13 +5,12 @@ InteractRunner.addActionConfig( {
 	cssRule: {
 		initAction: action => {
 			const property = action.getValue( 'property' )
-			const value = () => {
-				// Get the value, pass the style name as the context.
-				return action.getValue( 'value', action.getValue( 'property' ) )
-			}
+			// Get the value, pass the style name as the context.
+			const value = action.getValue( 'value', action.getValue( 'property' ) )
+
 			// Validate the CSS rule first.
 			// Add optional 'px' to allow values without unit which default to px.
-			if ( CSS.supports( property, value() ) || CSS.supports( property, value() + 'px' ) ) {
+			if ( CSS.supports( property, value ) || CSS.supports( property, value + 'px' ) ) {
 				return action.initActionAnimation( {
 					[ property ]: value,
 					// This makes sure the value is re-calculated for dynamic values.


### PR DESCRIPTION
fixes #8

Using the actual value has the same behavior with the previous wrapped in a function, but without the editor error.