### PR TITLE
fix/14 editor show template

### DIFF
--- a/src/editor/components/timeline/runner.js
+++ b/src/editor/components/timeline/runner.js
@@ -2,7 +2,9 @@
  * The timeline runner that runs the animation when previewing.
  */
 import InteractEditorRunner from './class-runner'
-import { useRef, useMemo } from '@wordpress/element'
+import {
+	useRef, useState, useEffect,
+} from '@wordpress/element'
 import { cloneDeep } from 'lodash'
 import { getBlockClientId } from './with-tracked-anchors'
 import { doAction } from '@wordpress/hooks'
@@ -37,11 +39,13 @@ doAction( 'interact.interaction.types.loaded' )
 
 export const useTimelineRunnerRef = ( interaction, actions, timelineIndex ) => {
 	const runnerRef = useRef( null )
+	const [ initialStyles, setInitialStyles ] = useState( '' )
+
 	const renderingMode = select( 'core/editor' ).getRenderingMode()
 	const prevRenderingMode = useRef( renderingMode )
 
 	// Initialize the runner
-	const initialStyles = useMemo( () => {
+	useEffect( () => {
 		// We will need to spawn a new runner for each timeline. Spawning will
 		// create a new running with the same configuration.
 		if ( ! runnerRef.current ) {
@@ -62,18 +66,18 @@ export const useTimelineRunnerRef = ( interaction, actions, timelineIndex ) => {
 			replaceBlockAnchorsForEditor( isolatedInteraction )
 			runnerRef.current?.configure( [ isolatedInteraction ] )
 			runnerRef.current?.init()
+			setInitialStyles( runnerRef.current?.getStartingActionStyles() || '' )
 		}
 
 		// If the rendering mode changed, we need to delay the init to
 		// avoid race condition tracking the anchors.
 		if ( prevRenderingMode.current !== renderingMode ) {
-			setTimeout( initRunner, 0 )
+			requestAnimationFrame( initRunner )
 		} else {
 			initRunner()
 		}
-		prevRenderingMode.current = renderingMode
 
-		return runnerRef.current?.getStartingActionStyles() || ''
+		prevRenderingMode.current = renderingMode
 	}, [ interaction, timelineIndex, actions, renderingMode ] )
 
 	return [ runnerRef, initialStyles ]

--- a/src/editor/components/timeline/runner.js
+++ b/src/editor/components/timeline/runner.js
@@ -6,6 +6,7 @@ import { useRef, useMemo } from '@wordpress/element'
 import { cloneDeep } from 'lodash'
 import { getBlockClientId } from './with-tracked-anchors'
 import { doAction } from '@wordpress/hooks'
+import { select } from '@wordpress/data'
 
 // Create the runner.
 const runner = new InteractEditorRunner()
@@ -36,6 +37,8 @@ doAction( 'interact.interaction.types.loaded' )
 
 export const useTimelineRunnerRef = ( interaction, actions, timelineIndex ) => {
 	const runnerRef = useRef( null )
+	const renderingMode = select( 'core/editor' ).getRenderingMode()
+	const prevRenderingMode = useRef( renderingMode )
 
 	// Initialize the runner
 	const initialStyles = useMemo( () => {
@@ -52,16 +55,26 @@ export const useTimelineRunnerRef = ( interaction, actions, timelineIndex ) => {
 			actions: cloneDeep( actions ),
 		} ]
 
-		// This replaces all block anchors with the block's ID. The editor
-		// doesn't show block anchors, since it's always in the format of
-		// "block-clientId"
-		replaceBlockAnchorsForEditor( isolatedInteraction )
+		const initRunner = () => {
+			// This replaces all block anchors with the block's ID. The editor
+			// doesn't show block anchors, since it's always in the format of
+			// "block-clientId"
+			replaceBlockAnchorsForEditor( isolatedInteraction )
+			runnerRef.current?.configure( [ isolatedInteraction ] )
+			runnerRef.current?.init()
+		}
 
-		runnerRef.current?.configure( [ isolatedInteraction ] )
-		runnerRef.current?.init()
+		// If the rendering mode changed, we need to delay the init to
+		// avoid race condition tracking the anchors.
+		if ( prevRenderingMode.current !== renderingMode ) {
+			setTimeout( initRunner, 0 )
+		} else {
+			initRunner()
+		}
+		prevRenderingMode.current = renderingMode
 
 		return runnerRef.current?.getStartingActionStyles() || ''
-	}, [ interaction, timelineIndex, actions ] )
+	}, [ interaction, timelineIndex, actions, renderingMode ] )
 
 	return [ runnerRef, initialStyles ]
 }

--- a/src/editor/components/timeline/with-tracked-anchors.js
+++ b/src/editor/components/timeline/with-tracked-anchors.js
@@ -40,7 +40,18 @@ const withTrackedAnchors = createHigherOrderComponent( BlockEdit => {
 
 			// Store anchor for next render
 			prevAnchorRef.current = anchor
+
+			// Cleanup function to remove the entry when the block is unmounted
+			return () => {
+				const index = ANCHORS.indexOf( anchor )
+				if ( index !== -1 ) {
+					ANCHORS.splice( index, 1 )
+					CLIENT_IDS.splice( index, 1 )
+				}
+			}
 		}, [ props.clientId, props.attributes?.anchor ] )
+
+		console.log( ANCHORS, CLIENT_IDS )
 
 		return <BlockEdit { ...props } />
 	}

--- a/src/editor/components/timeline/with-tracked-anchors.js
+++ b/src/editor/components/timeline/with-tracked-anchors.js
@@ -41,7 +41,7 @@ const withTrackedAnchors = createHigherOrderComponent( BlockEdit => {
 			// Store anchor for next render
 			prevAnchorRef.current = anchor
 
-			// Cleanup function to remove the entry when the block is unmounted
+			// Cleanup when the block is unmounted
 			return () => {
 				const index = ANCHORS.indexOf( anchor )
 				if ( index !== -1 ) {
@@ -50,8 +50,6 @@ const withTrackedAnchors = createHigherOrderComponent( BlockEdit => {
 				}
 			}
 		}, [ props.clientId, props.attributes?.anchor ] )
-
-		console.log( ANCHORS, CLIENT_IDS )
 
 		return <BlockEdit { ...props } />
 	}

--- a/src/editor/components/timeline/with-tracked-anchors.js
+++ b/src/editor/components/timeline/with-tracked-anchors.js
@@ -1,4 +1,4 @@
-import { useEffect } from '@wordpress/element'
+import { useEffect, useRef } from '@wordpress/element'
 import { createHigherOrderComponent } from '@wordpress/compose'
 import { addFilter } from '@wordpress/hooks'
 
@@ -10,22 +10,37 @@ const CLIENT_IDS = []
 // ALL the time.
 const withTrackedAnchors = createHigherOrderComponent( BlockEdit => {
 	return props => {
+		const prevAnchorRef = useRef()
+
 		useEffect( () => {
-			if ( props.attributes.anchor ) {
-				// Remove any previous anchor selector for this clientId.
-				const index = CLIENT_IDS.indexOf( props.clientId )
-				if ( index !== -1 ) {
-					CLIENT_IDS.splice( index, 1 )
-					ANCHORS.splice( index, 1 )
-				}
-				// Keep track of the clientId-anchor pair
-				CLIENT_IDS.push( props.clientId )
-				ANCHORS.push( props.attributes.anchor )
+			const anchor = props.attributes?.anchor
+			if ( ! anchor ) {
+				return
 			}
-		}, [
-			props.clientId,
-			props.attributes?.anchor,
-		] )
+
+			// If this block had a previous anchor, remove it.
+			if ( prevAnchorRef.current ) {
+				const oldIndex = ANCHORS.indexOf( prevAnchorRef.current )
+				if ( oldIndex !== -1 ) {
+					ANCHORS.splice( oldIndex, 1 )
+					CLIENT_IDS.splice( oldIndex, 1 )
+				}
+			}
+
+			// Remove any existing entry for this anchor.
+			// This ensures no duplication when the blocks are re-rendered.
+			const existingIndex = ANCHORS.indexOf( anchor )
+			if ( existingIndex !== -1 ) {
+				ANCHORS.splice( existingIndex, 1 )
+				CLIENT_IDS.splice( existingIndex, 1 )
+			}
+
+			ANCHORS.push( anchor )
+			CLIENT_IDS.push( props.clientId )
+
+			// Store anchor for next render
+			prevAnchorRef.current = anchor
+		}, [ props.clientId, props.attributes?.anchor ] )
 
 		return <BlockEdit { ...props } />
 	}


### PR DESCRIPTION
fixes #14 

Observations:
- Issue is not related to additional wrapper when Show Template is on
- The issue only occurs when the element trigger is Block (using anchors)

Issues: 
- When Show Template is on, the editor renders the blocks twice (once for the template preview, once for the real editor, with both having different clientId) so it causes duplication in the HOC for tracking clientId/anchor pairs.
- Toggling Show Template re-renders all the blocks changing the clientId.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved timeline initialization stability during rendering-mode transitions, reducing glitches and delayed starts when switching editor modes.
  * Enhanced anchor tracking to eliminate duplicate entries in the timeline editor, preventing stale or conflicting anchors and improving editor reliability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->