### PR TITLE
Add Cursor Cloud dev environment setup instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,22 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+Interactions is a WordPress plugin (Trigger → Action animation/interactivity builder for the block editor, Elementor and Bricks). It only runs inside a WordPress install, so end-to-end testing needs a running WordPress with the built plugin activated.
+
+### Environment (already provisioned in the VM snapshot)
+- Node 22, PHP 8.3, Composer, Docker and `ffmpeg` are installed. `node_modules` is refreshed by the startup update script. This repo has no `composer.json`.
+- Docker is required for the WordPress test environment (`@wordpress/env`). The Docker daemon is not managed by systemd here; if `docker ps` fails, start it with `sudo dockerd` (a background/tmux process) — configured for the `fuse-overlayfs` storage driver and `iptables-legacy`.
+
+### Build / run / lint (see `package.json`, `BUILD.md`)
+- Dev (watch): `npm run start` — runs `wp-scripts start` plus a CSS webpack watch concurrently. Intended dev workflow.
+- One-shot build + zip: `npm run build` (its `prebuild` runs `npm run lint:js`; the build also compiles CSS, generates frontend PHP, and runs `optimize-videos` which needs `ffmpeg`).
+- Lint only: `npm run lint` (`lint:js` + `lint:css`).
+- Built assets land in `dist/` (and the packaged zip in `build/`); they must exist for the plugin to work in WordPress.
+
+### Shared WordPress dev environment (all three sibling plugins)
+- A `wp-env` project lives at `/home/ubuntu/wp-dev` with a `.wp-env.json` that mounts Cimo, Interactions and Stackable (by absolute path) into one WordPress site. It is kept out of the repos on purpose.
+- Start/stop: `cd /home/ubuntu/wp-dev && npx wp-env start` / `npx wp-env stop`. Run WP-CLI: `npx wp-env run cli wp <cmd>`.
+- Site: http://localhost:8888/wp-admin (user `admin`, password `password`). wp-env auto-activates the mounted plugins on start.
+- Hello-world check: in a post, select a block (e.g. a Button); open the block's Interactions toolbar icon / sidebar panel and add a Trigger (e.g. Mouse hover) + Action (e.g. Scale).
+- After changing plugin source, rebuild assets (`npm run build` or keep `npm run start` watching); wp-env serves the repo directory live, so no reinstall is needed.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds an `AGENTS.md` with a `## Cursor Cloud specific instructions` section so future cloud agents can build, run and test the Interactions plugin without rediscovering setup.

This is a docs-only change (no code changes). The dev environment was set up and verified end-to-end:

- Installed Node 22 deps (`npm install`). `ffmpeg` is present for the `optimize-videos` build step.
- `npm run build` compiled assets into `dist/` and produced `build/interactions-1.4.0.zip` (its `prebuild` `npm run lint:js` passed).
- Ran WordPress via `@wordpress/env` (Docker) at `http://localhost:8888`, plugin auto-activated with no PHP errors.

## Hello-world verification

In a post, selected a Button block, opened the Interactions panel, and configured a Trigger → Action interaction (Mouse hover → Scale). The Add Action modal exposes the full action set (Scale, Rotate, Opacity, Move, etc.).

[Add Action modal showing available actions](https://cursor.com/agents/bc-bd4c2627-aa36-42fa-99d5-94372e57e7ba/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Finteractions_dac88.webp)

[interactions_52f28.webp](https://cursor.com/agents/bc-bd4c2627-aa36-42fa-99d5-94372e57e7ba/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Finteractions_52f28.webp) Scale interaction" />

## Notes

- Docker is required for `@wordpress/env` and is not managed by systemd in the VM; start with `sudo dockerd` if `docker ps` fails.
- The shared `wp-env` config (mounting Cimo, Interactions and Stackable) is kept at `/home/ubuntu/wp-dev`, out of the repo on purpose.

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-bd4c2627-aa36-42fa-99d5-94372e57e7ba"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-bd4c2627-aa36-42fa-99d5-94372e57e7ba"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

