### PR TITLE
fix: cache location rules responses client-side (#29)

### DIFF
--- a/src/editor/components/location-rules/index.js
+++ b/src/editor/components/location-rules/index.js
@@ -59,6 +59,27 @@ const addLocation = ( locations, index1, index2, newLocation ) => {
 	return newLocations
 }
 
+// Module-level cache of location rule responses keyed by `param`. The endpoint
+// runs potentially expensive, unbounded queries (see issue #29), so we memoize
+// each param's response and share in-flight requests across every LocationRule
+// instance to avoid redundant/parallel fetches.
+const locationRulesCache = new Map()
+
+const fetchLocationRules = param => {
+	if ( ! locationRulesCache.has( param ) ) {
+		const request = apiFetch( {
+			path: `/interact/v1/get_location_rules/${ param }`,
+			method: 'GET',
+		} ).catch( error => {
+			// Don't cache failed requests so they can be retried later.
+			locationRulesCache.delete( param )
+			throw error
+		} )
+		locationRulesCache.set( param, request )
+	}
+	return locationRulesCache.get( param )
+}
+
 // Flatten the editor options so we can easily check them without looping
 // through all the options.
 const ruleEditorOptions = {}
@@ -143,14 +164,18 @@ const LocationRule = props => {
 	const [ isBusy, setIsBusy ] = useState( false )
 
 	useEffect( () => {
+		let isMounted = true
 		setIsBusy( true )
-		apiFetch( {
-			path: `/interact/v1/get_location_rules/${ param }`,
-			method: 'GET',
-		} )
+		fetchLocationRules( param )
 			.then( response => {
+				if ( ! isMounted ) {
+					return
+				}
 				setIsBusy( false )
-				const options = response
+
+				// Clone the cached response so we never mutate the shared cache
+				// when adding the "Current Post/Page" option below.
+				const options = cloneDeep( response )
 
 				// If param is a post/page, then the post_id doesn't exist yet, then we need to add it near the top as "Current Post" or "Current Page"
 				if ( param === 'post' || param === 'page' ) {
@@ -179,8 +204,16 @@ const LocationRule = props => {
 				setValueOptions( options )
 			} )
 			.catch( error => {
+				if ( ! isMounted ) {
+					return
+				}
+				setIsBusy( false )
 				console.error( 'Interactions error getting location rules:', error ) // eslint-disable-line no-console
 			} )
+
+		return () => {
+			isMounted = false
+		}
 	}, [ param ] )
 
 	const {


### PR DESCRIPTION
## Summary

Fixes #29 — the location rules fetch can be a PHP performance bottleneck.

The `/interact/v1/get_location_rules/{type}` endpoint runs unbounded `get_posts( [ 'posts_per_page' => -1 ] )` queries for `post`/`page` rules. On the client it was fired **per `LocationRule` instance, on mount and on every `param` change, with no caching or dedup** — so multiple rules meant multiple parallel unbounded queries and large repeated payloads that scale badly with site size.

This applies the recommended client-side fix:

- Adds a module-level cache keyed by `param` that memoizes each response.
- Shares in-flight requests across all `LocationRule` instances (dedup), so simultaneous mounts trigger a single request per `param`.
- Clones the cached response before injecting the "Current Post/Page" option, so the shared cache is never mutated.
- Does **not** cache failed requests, so they can be retried.
- Guards the effect against `setState` after unmount and resets the busy state on error.

No server-side or API changes; behavior is identical from the user's perspective, just without the redundant repeated queries.

## Test plan

- [ ] Open the interaction editor and add multiple location rules using the same param (e.g. several `post` rules) — verify only one network request per param in the Network tab.
- [ ] Switch a rule's param back and forth (e.g. `post` -> `page` -> `post`) — verify the second visit to a param serves from cache with no new request.
- [ ] Confirm the "Current Post"/"Current Page" option still appears correctly and is not duplicated.
- [ ] Simulate a failed request and confirm it retries on next mount (not cached).

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved location-rule loading reliability by reusing requests and allowing failed requests to retry.
  * Prevented errors when navigating away before location rules finish loading.
  * Ensured dynamically added options do not affect shared data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->