### PR TITLE
fix: initialize interactions when configure runs after init (caching/defer plugins)

### DIFF
--- a/src/frontend/scripts/class-runner.js
+++ b/src/frontend/scripts/class-runner.js
@@ -13,6 +13,7 @@ class InteractRunner {
 		this._startingStyles = ''
 		this.isFrontend = true
 		this.interactions = []
+		this._isInitialized = false
 	}
 
 	// Spawn an identical runner
@@ -97,6 +98,15 @@ class InteractRunner {
 		// the starting state, so that when the page loads, it will be in
 		// the starting state and won't flicker.
 		this.configureStartingActions()
+
+		// If init() already ran before this configuration arrived, initialize
+		// the newly created interactions now. Caching/defer plugins (e.g.
+		// SiteGround Speed Optimizer) can change script execution order so that
+		// init() fires before configure(), leaving interactions inert until
+		// InteractRunner.init() is called manually. See WP-Interactions #4.
+		if ( this._isInitialized ) {
+			this.init()
+		}
 	}
 
 	/**
@@ -168,6 +178,8 @@ class InteractRunner {
 		this.interactions.forEach( interaction => {
 			interaction.init()
 		} )
+
+		this._isInitialized = true
 	}
 
 	/**
@@ -179,6 +191,8 @@ class InteractRunner {
 		this.interactions.forEach( interaction => {
 			interaction.destroy()
 		} )
+
+		this._isInitialized = false
 	}
 }
 

--- a/src/frontend/scripts/class-runner.js
+++ b/src/frontend/scripts/class-runner.js
@@ -104,7 +104,11 @@ class InteractRunner {
 		// SiteGround Speed Optimizer) can change script execution order so that
 		// init() fires before configure(), leaving interactions inert until
 		// InteractRunner.init() is called manually. See WP-Interactions #4.
-		if ( this._isInitialized ) {
+		//
+		// This only applies on the frontend. The editor calls configure() then
+		// init() itself on every preview refresh, so auto-initializing here
+		// would double-init and duplicate listeners.
+		if ( this.isFrontend && this._isInitialized ) {
 			this.init()
 		}
 	}


### PR DESCRIPTION
## Summary

Fixes gambitph/WP-Interactions#4 — interactions/animations sometimes don't start on the frontend when a caching/defer plugin (e.g. **SiteGround Speed Optimizer** with *Minify JavaScript* + *Defer Render-blocking JavaScript*) is active. The page loads but nothing animates until `InteractRunner.init()` is run manually.

## Root cause

There's a race between `InteractRunner.configure()` (builds the interactions, output as an inline script) and `InteractRunner.init()` (scheduled by `frontend.js` on `domReady`).

- **Normal load:** the inline script runs `configure()` synchronously, then `DOMContentLoaded` runs `init()`. Order is correct.
- **With defer/combine:** the main bundle is deferred, so the inline "checkRunner" script can't find `InteractRunner` yet and starts polling every 10ms. When the deferred bundle finally runs `frontend.js`, the DOM is already parsed so `domReady` fires immediately and schedules `init()` at +1ms. `init()` wins the race and runs against an **empty** interactions list; `configure()` builds the interactions ~10ms later, but nothing calls `init()` again → inert page.

## Fix

Make the runner order-independent in `src/frontend/scripts/class-runner.js`:

- Track `_isInitialized` (set in `init()`, cleared in `destroy()`).
- If `configure()` runs after `init()` already ran, initialize the freshly-built interactions immediately.

The normal path is unchanged (`configure()` runs first, `_isInitialized` is false, no extra init).

## Test plan

- [ ] Build and load a page with an interaction (e.g. "On hover, fade out element") with **no** caching plugin — verify it still works.
- [ ] Enable SiteGround Speed Optimizer with *Minify JavaScript Files* + *Defer Render-blocking JavaScript*, load in incognito, and repeatedly trigger the interaction — verify it now consistently works without manually calling `InteractRunner.init()`.
- [ ] Verify no duplicate event listeners / double-init in the normal (non-cached) flow.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved interaction initialization when configuration occurs after startup.
  * Ensured interactions are correctly reinitialized after being destroyed and recreated.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->